### PR TITLE
Remove develop

### DIFF
--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -1761,8 +1761,6 @@ Available commands:
   $SCRIPT_NAME_LOWER startup force      runs startup actions such as mount WebUI tab
   $SCRIPT_NAME_LOWER install            installs script
   $SCRIPT_NAME_LOWER uninstall          uninstalls script
-  $SCRIPT_NAME_LOWER develop            switch to development branch
-  $SCRIPT_NAME_LOWER stable             switch to stable branch
 EOF
 	printf "\\n"
 }
@@ -1909,18 +1907,6 @@ case "$1" in
 	help)
 		ScriptHeader
 		Show_Help
-		exit 0
-	;;
-	develop)
-		SCRIPT_BRANCH="develop"
-		SCRIPT_REPO="https://raw.githubusercontent.com/decoderman/$SCRIPT_NAME/$SCRIPT_BRANCH"
-		Update_Version force
-		exit 0
-	;;
-	stable)
-		SCRIPT_BRANCH="master"
-		SCRIPT_REPO="https://raw.githubusercontent.com/decoderman/$SCRIPT_NAME/$SCRIPT_BRANCH"
-		Update_Version force
 		exit 0
 	;;
 	*)


### PR DESCRIPTION
No need to have a develop branch, as it wasn't forked.

ToDo: completely remove references to branches (as in urls)

Note - tried to switch do develop branch, with decoderman fork, and the result was bork. Null develop version and a loop trying to update the script. Better to remove it.