### PR TITLE
Fixes for the webGUI running on the 3006.102.1 F/W version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # scMerlin
 
-## v2.5.4
-### Updated on June 02, 2024 by @decoderman with updates from @Martinski4GitHub
+## v2.5.5
+### Updated on June 24, 2024 by @decoderman with updates from @Martinski4GitHub
 ## About
 scMerlin allows you to easily control the most common services/scripts on your router. scMerlin also augments your router's WebUI with a Sitemap and dynamic submenus for the main left menu of Asuswrt-Merlin.
 

--- a/scmerlin.sh
+++ b/scmerlin.sh
@@ -11,7 +11,7 @@
 ##       https://github.com/jackyaz/scMerlin        ##
 ##                                                  ##
 ######################################################
-# Last Modified: 2024-Jun-07
+# Last Modified: 2024-Jun-24
 #-----------------------------------------------------
 
 ##########       Shellcheck directives     ###########
@@ -26,8 +26,8 @@
 ### Start of script variables ###
 readonly SCRIPT_NAME="scMerlin"
 readonly SCRIPT_NAME_LOWER="$(echo "$SCRIPT_NAME" | tr 'A-Z' 'a-z' | sed 's/d//')"
-readonly SCM_VERSION="v2.5.4"
-readonly SCRIPT_VERSION="v2.5.4"
+readonly SCM_VERSION="v2.5.5"
+readonly SCRIPT_VERSION="v2.5.5"
 SCRIPT_BRANCH="master"
 SCRIPT_REPO="https://raw.githubusercontent.com/decoderman/$SCRIPT_NAME/$SCRIPT_BRANCH"
 readonly SCRIPT_DIR="/jffs/addons/$SCRIPT_NAME_LOWER.d"

--- a/scmerlin_www.asp
+++ b/scmerlin_www.asp
@@ -169,7 +169,7 @@ else
 }
 
 /**----------------------------------------**/
-/** Modified by Martinski W. [2024-Jun-01] **/
+/** Modified by Martinski W. [2024-Jun-24] **/
 /**----------------------------------------**/
 function GetTemperatureValue (bandIDstr)
 {
@@ -182,7 +182,7 @@ function GetTemperatureValue (bandIDstr)
                 productid == 'GT-BE98_PRO' ||
                 productid == 'GT-AXE16000')
             {
-                if (typeof curr_coreTmp_wl3_raw != 'undefined' && curr_coreTmp_wl3_raw != null)
+                if (typeof curr_coreTmp_wl3_raw != 'undefined')
                 { temperatureVal = curr_coreTmp_wl3_raw; }
                 else if (typeof curr_coreTmp_3_raw != 'undefined' && curr_coreTmp_3_raw != null)
                 { temperatureVal = curr_coreTmp_3_raw; }
@@ -200,7 +200,7 @@ function GetTemperatureValue (bandIDstr)
                 productid == 'GT-BE98_PRO' ||
                 productid == 'GT-AXE16000')
             {
-                if (typeof curr_coreTmp_wl0_raw != 'undefined' && curr_coreTmp_wl0_raw != null)
+                if (typeof curr_coreTmp_wl0_raw != 'undefined')
                 { temperatureVal = curr_coreTmp_wl0_raw; }
                 else if (typeof curr_coreTmp_0_raw != 'undefined' && curr_coreTmp_0_raw != null)
                 { temperatureVal = curr_coreTmp_0_raw; }
@@ -217,7 +217,7 @@ function GetTemperatureValue (bandIDstr)
             if (productid == 'GT-BE98' ||
                 productid == 'GT-AXE16000')
             {
-                if (typeof curr_coreTmp_wl1_raw != 'undefined' && curr_coreTmp_wl1_raw != null)
+                if (typeof curr_coreTmp_wl1_raw != 'undefined')
                 { temperatureVal = curr_coreTmp_wl1_raw; }
                 else if (typeof curr_coreTmp_1_raw != 'undefined' && curr_coreTmp_1_raw != null)
                 { temperatureVal = curr_coreTmp_1_raw; }
@@ -234,7 +234,7 @@ function GetTemperatureValue (bandIDstr)
         case '6GHz_1':
             if (productid == 'GT-BE98_PRO')
             {
-                if (typeof curr_coreTmp_wl1_raw != 'undefined' && curr_coreTmp_wl1_raw != null)
+                if (typeof curr_coreTmp_wl1_raw != 'undefined')
                 { temperatureVal = curr_coreTmp_wl1_raw; }
                 else if (typeof curr_coreTmp_1_raw != 'undefined' && curr_coreTmp_1_raw != null)
                 { temperatureVal = curr_coreTmp_1_raw; }
@@ -249,7 +249,7 @@ function GetTemperatureValue (bandIDstr)
         case '6GHz_2':
             if (productid == 'GT-BE98_PRO')
             {
-                if (typeof curr_coreTmp_wl2_raw != 'undefined' && curr_coreTmp_wl2_raw != null)
+                if (typeof curr_coreTmp_wl2_raw != 'undefined')
                 { temperatureVal = curr_coreTmp_wl2_raw; }
             }
             break;

--- a/scmerlin_www.asp
+++ b/scmerlin_www.asp
@@ -17,6 +17,7 @@ p{font-weight:bolder}thead.collapsible-jquery{color:#fff;padding:0;width:100%;bo
 <script language="JavaScript" type="text/javascript" src="/ext/shared-jy/moment.js"></script>
 <script language="JavaScript" type="text/javascript" src="/ext/shared-jy/chart.js"></script>
 <script language="JavaScript" type="text/javascript" src="/ext/shared-jy/hammerjs.js"></script>
+<script language="JavaScript" type="text/javascript" src="/js/jquery.js"></script>
 <script language="JavaScript" type="text/javascript" src="/js/httpApi.js"></script>
 <script language="JavaScript" type="text/javascript" src="/state.js"></script>
 <script language="JavaScript" type="text/javascript" src="/general.js"></script>


### PR DESCRIPTION
1) FIXED another error when loading the webGUI page on the 3006.102.1 F/W version.

2) FIXED code to get the correct temperatures on the webGUI for the 6GHz bands on the BE-class routers.
